### PR TITLE
fix(version): windows_exporter updated to `0.25.1` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Requirements
 Role Variables
 --------------
 
-- `windows_exporter_version` The specific version of Windows Exporter to download (default: `0.24.0`).
-- `windows_exporter_package_name` Windows Exporter package name (default: `windows_exporter-0.24.0-amd64.msi`).
-- `windows_exporter_download_url` URL to download Windows Exporter package (default: `https://github.com/prometheus-community/windows_exporter/releases/download/v0.24.0`).
+- `windows_exporter_version` The specific version of Windows Exporter to download (default: `0.25.1`).
+- `windows_exporter_package_name` Windows Exporter package name (default: `windows_exporter-0.25.1-amd64.msi`).
+- `windows_exporter_download_url` URL to download Windows Exporter package (default: `https://github.com/prometheus-community/windows_exporter/releases/download/v0.25.1`).
 - `windows_exporter_listen_address` The IP address to bind to (default: `0.0.0.0`).
 - `windows_exporter_listen_port` The port to bind to (default: `9182`).
 - `windows_exporter_metrics_path` The path at which to serve metrics (default: `metrics`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/prometheus-community/windows_exporter/releases
-windows_exporter_version: '0.24.0'
+windows_exporter_version: '0.25.1'
 windows_exporter_package_name: 'windows_exporter-{{ windows_exporter_version }}-{{ _windows_exporter_arch }}.msi'
 windows_exporter_download_url: 'https://github.com/prometheus-community/windows_exporter/releases/download/v{{ windows_exporter_version }}'
 


### PR DESCRIPTION
The upstream [windows_exporter](https://github.com/prometheus-community/windows_exporter/releases) released new software version - **0.25.1**!

This automated PR updates code to bring new version into repository.