### PR TITLE
fix: never use sudo for downloading windows_exporter

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,6 +27,7 @@
         mode: 0644
       delegate_to: localhost
       check_mode: false
+      become: false
 
     - name: 'Copy the Windows Exporter package into a place'
       ansible.windows.win_copy:


### PR DESCRIPTION
* When antmelekhin.windows_exporter role is being called as a sub-role and the "download windows exporter" task is inheriting become: true this task might fail to ansible process not being able to become sudo on localhost.
* In prometheus ansible collection other exporters like node_exporter also explicitly set become to false in tasks that have delegate_to: localhost
* Runs fine with become_fase as this does not need elevated privileges