### PR TITLE
fix: normalize ansible_architecture before mapping it in __windows_exporter_architecture evaluation

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,4 +3,4 @@ __windows_exporter_architecture_dict:
   32-bit: '386'
   64-bit: 'amd64'
 
-__windows_exporter_architecture: '{{ __windows_exporter_architecture_dict[ansible_architecture] | default(ansible_architecture) }}'
+__windows_exporter_architecture: '{{ __windows_exporter_architecture_dict[ansible_architecture | lower()] | default(ansible_architecture | lower()) }}'


### PR DESCRIPTION
* Not on all Windows versions the "-bit" substring in ansible_architecture is spelled in lowercase. On some Windows versions ansible_architecture contains "-Bit" spelled with a capital B which results in the mapping not matching and therefore a failing download of windows_exporter.
* This commit fixes deployment on some Windows versions like e.g. Windows 10 (tested)