### PR TITLE
fix(version): windows_exporter updated to `0.30.6` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/prometheus-community/windows_exporter/releases
-windows_exporter_version: '0.30.5'
+windows_exporter_version: '0.30.6'
 windows_exporter_package_name: 'windows_exporter-{{ windows_exporter_version }}-{{ __windows_exporter_architecture }}.msi'
 windows_exporter_download_url: 'https://github.com/prometheus-community/windows_exporter/releases/download/v{{ windows_exporter_version }}'
 windows_exporter_checksum_url: '{{ windows_exporter_download_url }}/sha256sums.txt'

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -9,7 +9,7 @@ argument_specs:
       windows_exporter_version:
         type: 'str'
         description: 'The version of Windows Exporter to install.'
-        default: '0.30.5'
+        default: '0.30.6'
       windows_exporter_package_name:
         type: 'str'
         description: 'The Windows Exporter package name.'


### PR DESCRIPTION
The upstream [windows_exporter](https://github.com/prometheus-community/windows_exporter/releases) released new software version - **0.30.6**!

This automated PR updates code to bring new version into repository.